### PR TITLE
[RFC] Generate user documentation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
     - CI_TARGET=rebuild-deps32
     - CI_TARGET=rebuild-deps64
     - CI_TARGET=translation-report
+    - CI_TARGET=user-docu
     - CI_TARGET=vimpatch-report
 script:
   - ./ci/${CI_TARGET}.sh

--- a/ci/user-docu.sh
+++ b/ci/user-docu.sh
@@ -1,0 +1,39 @@
+#!/bin/bash -e
+
+BUILD_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source ${BUILD_DIR}/ci/common/common.sh
+source ${BUILD_DIR}/ci/common/doc.sh
+source ${BUILD_DIR}/ci/common/neovim.sh
+source ${BUILD_DIR}/ci/common/html.sh
+
+generate_user_docu() {
+  require_environment_variable BUILD_DIR "${BASH_SOURCE[0]}" ${LINENO}
+  require_environment_variable MAKE_CMD "${BASH_SOURCE[0]}" ${LINENO}
+
+  cd ${NEOVIM_DIR}/runtime/doc
+  ${MAKE_CMD} html
+
+  # Copy to doc repository
+  rm -rf ${DOC_DIR}/user
+  mkdir -p ${DOC_DIR}/user
+  cp -r *.html ${DOC_DIR}/user
+
+  # Modify HTML to match Neovim's layout
+  modify_user_docu
+}
+
+# Helper function to modify user documentation HTML
+# to use Neovim layout
+modify_user_docu() {
+  for file in ${DOC_DIR}/user/*.html; do
+    local title="$(extract_title ${file})"
+    local body="$(echo "$(extract_body ${file})" | sed -e 's/color="purple"/color="#54A23D"/Ig')"
+    generate_report "${title}" "${body}" "${file}"
+  done
+}
+
+DOC_SUBTREE="/user/"
+clone_doc
+clone_neovim
+generate_user_docu
+commit_doc

--- a/templates/report-footer.sh.html
+++ b/templates/report-footer.sh.html
@@ -1,0 +1,9 @@
+    </div>
+
+    <footer>
+      <div class="container">
+        Generated ${report_date} from <a href="https://github.com/${report_repo}/commit/${report_commit}"><code>${report_short_commit}</code></a>.
+      </div>
+    </footer>
+  </body>
+</html>

--- a/templates/report-header.sh.html
+++ b/templates/report-header.sh.html
@@ -12,7 +12,7 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
-    ${report_header}
+    ${report_head}
   </head>
   <body>
     <header class="navbar">
@@ -28,13 +28,3 @@
 
     <div class="container">
       <h1>${report_title}</h1>
-      ${report_body}
-    </div>
-
-    <footer>
-      <div class="container">
-        Generated ${report_date} from <a href="https://github.com/${report_repo}/commit/${report_commit}"><code>${report_short_commit}</code></a>.
-      </div>
-    </footer>
-  </body>
-</html>


### PR DESCRIPTION
With neovim/neovim#1011, HTML user documentation can be generated. If the [build](https://travis-ci.org/fwalch/bot-ci/builds/31241189) passes, the user docu should show up at https://fwalch.github.io/doc/user.

I used a similar approach to the clang report to wrap the docu in Neovim's layout. Unfortunately, the contents of eval.html (9000 lines or so?) were too much for envsubst, so I had to modify `generate_report` to echo the body directly.
