### PR TITLE
[RFC] Install only necessary dependencies for each build type.

### DIFF
--- a/ci/common/dependencies.sh
+++ b/ci/common/dependencies.sh
@@ -3,51 +3,60 @@
 # Required environment variables:
 # ${BUILD_DIR}
 
-install_dependencies() {
-  if [[ ${CI} != true ]]; then
-    echo "Local build, not installing dependencies."
-    return
-  fi
+DOXYGEN_VERSION=${DOXYGEN_VERSION:-1.8.7}
+CLANG_VERSION=${CLANG_VERSION:-3.4}
+NEOVIM_DEPS_REPO=${NEOVIM_DEPS_REPO:-neovim/deps}
+NEOVIM_DEPS_BRANCH=${NEOVIM_DEPS_BRANCH:-master}
+NEOVIM_DEPS_DIR=${NEOVIM_DEPS_DIR:-/opt/neovim-deps}
 
-  local doxygen_version=1.8.7
-  local clang_version=3.4
-  local neovim_deps_repo=neovim/deps
-  local neovim_deps_branch=master
-  local neovim_deps_dir=/opt/neovim-deps
+# Define directories where dependencies are installed to
+DEPS_INSTALL_DIR=${DEPS_INSTALL_DIR:-${BUILD_DIR}/build/.deps}
+DEPS_BIN_DIR=${DEPS_BIN_DIR:-${DEPS_INSTALL_DIR}/bin}
+export PATH="${DEPS_BIN_DIR}:${PATH}"
 
-  local deps_dir=${BUILD_DIR}/build/.deps
-  local bin_dir=${deps_dir}/bin
+install_doxygen() {
+  mkdir -p ${DEPS_INSTALL_DIR} ${DEPS_BIN_DIR}
 
-  mkdir -p ${deps_dir}
-  mkdir -p ${bin_dir}
+  echo "Installing Doxygen ${DOXYGEN_VERSION}..."
+  mkdir -p ${DEPS_INSTALL_DIR}/doxygen
+  wget -q -O - http://ftp.stack.nl/pub/users/dimitri/doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz \
+    | tar xzf - --strip-components=1 -C ${DEPS_INSTALL_DIR}/doxygen
+  ln -fs ${DEPS_INSTALL_DIR}/doxygen/bin/doxygen ${DEPS_BIN_DIR}
+}
 
-  # Install doxygen
-  echo "Installing Doxygen ${doxygen_version}..."
-  mkdir -p ${deps_dir}/doxygen
-  wget -q -O - http://ftp.stack.nl/pub/users/dimitri/doxygen-${doxygen_version}.linux.bin.tar.gz \
-    | tar xzf - --strip-components=1 -C ${deps_dir}/doxygen
-  ln -fs ${deps_dir}/doxygen/bin/doxygen ${bin_dir}
+install_clang() {
+  mkdir -p ${DEPS_BIN_DIR}
 
-  # Install scan-build from PPA
-  echo "Installing Clang ${clang_version}..."
+  echo "Installing Clang ${CLANG_VERSION}..."
   sudo add-apt-repository 'deb http://llvm.org/apt/precise/ llvm-toolchain-precise main'
   wget -q -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
   sudo apt-get update -qq
-  sudo apt-get install -y -q clang-${clang_version}
-  ln -fs /usr/bin/clang ${bin_dir}
-  ln -fs /usr/bin/scan-build ${bin_dir}
+  sudo apt-get install -y -q clang-${CLANG_VERSION}
 
-  # Install jq (http://stedolan.github.io/jq)
+  ln -fs /usr/bin/clang ${DEPS_BIN_DIR}
+  ln -fs /usr/bin/scan-build ${DEPS_BIN_DIR}
+}
+
+# For info on jq, see https://stedolan.github.io/jq
+install_jq() {
+  mkdir -p ${DEPS_BIN_DIR}
+
+  echo "Installing jq..."
+  sudo apt-get update -qq
   sudo apt-get install -y -q jq
 
-  # Setup prebuilt dependencies
-  echo "Setting up prebuilt dependencies from ${neovim_deps_repo}..."
-  sudo git clone --branch ${neovim_deps_branch} --depth 1 git://github.com/${neovim_deps_repo} ${neovim_deps_dir}
-  eval $(${neovim_deps_dir}/bin/luarocks path)
-  export PKG_CONFIG_PATH="${neovim_deps_dir}/lib/pkgconfig"
-  export USE_BUNDLED_DEPS=OFF
-  ln -fs ${neovim_deps_dir}/bin/* ${bin_dir}
+  ln -fs /usr/bin/jq ${DEPS_BIN_DIR}
+}
 
-  # Update PATH
-  export PATH="${bin_dir}:${PATH}"
+setup_neovim_deps() {
+  mkdir -p ${DEPS_BIN_DIR}
+
+  echo "Setting up prebuilt dependencies from ${NEOVIM_DEPS_REPO} ${NEOVIM_DEPS_BRANCH}..."
+
+  sudo git clone --branch ${NEOVIM_DEPS_BRANCH} --depth 1 git://github.com/${NEOVIM_DEPS_REPO} ${NEOVIM_DEPS_DIR}
+  eval $(${NEOVIM_DEPS_DIR}/bin/luarocks path)
+  export PKG_CONFIG_PATH="${NEOVIM_DEPS_DIR}/lib/pkgconfig"
+  export USE_BUNDLED_DEPS=OFF
+
+  ln -fs ${NEOVIM_DEPS_DIR}/bin/* ${DEPS_BIN_DIR}
 }

--- a/ci/doc-index.sh
+++ b/ci/doc-index.sh
@@ -3,16 +3,14 @@
 BUILD_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source ${BUILD_DIR}/ci/common/documentation.sh
 
-INDEX_PAGE_URL=${INDEX_PAGE_URL:-http://neovim.org/doc_index}
+DOC_INDEX_PAGE_URL=${DOC_INDEX_PAGE_URL:-http://neovim.org/doc_index}
 
 generate_doc_index() {
-  echo "Updating index.html from ${INDEX_PAGE_URL}."
-  wget -q ${INDEX_PAGE_URL} -O ${DOC_DIR}/index.html
+  echo "Updating index.html from ${DOC_INDEX_PAGE_URL}."
+  wget -q ${DOC_INDEX_PAGE_URL} -O ${DOC_DIR}/index.html
 }
 
-(
-  DOC_SUBTREE="/index.html"
-  clone_doc
-  generate_doc_index
-  commit_doc
-)
+DOC_SUBTREE="/index.html"
+clone_doc
+generate_doc_index
+commit_doc

--- a/ci/doxygen.sh
+++ b/ci/doxygen.sh
@@ -13,11 +13,12 @@ generate_doxygen() {
   mv build/doxygen/html ${DOC_DIR}/dev
 }
 
-(
-  DOC_SUBTREE="/dev/"
-  install_dependencies
-  clone_doc
-  clone_neovim
-  generate_doxygen
-  commit_doc
-)
+is_ci_build? && {
+  install_doxygen
+}
+
+DOC_SUBTREE="/dev/"
+clone_doc
+clone_neovim
+generate_doxygen
+commit_doc

--- a/ci/translation-report.sh
+++ b/ci/translation-report.sh
@@ -69,11 +69,12 @@ get_translation_report_body() {
   done
 }
 
-(
-  DOC_SUBTREE="/reports/translations/"
-  install_dependencies
-  clone_doc
-  clone_neovim
-  generate_translation_report
-  commit_doc
-)
+is_ci_build? && {
+  setup_neovim_deps
+}
+
+DOC_SUBTREE="/reports/translations/"
+clone_doc
+clone_neovim
+generate_translation_report
+commit_doc

--- a/ci/vimpatch-report.sh
+++ b/ci/vimpatch-report.sh
@@ -54,11 +54,12 @@ get_open_pullrequests() {
   echo "</div>"
 }
 
-(
-  DOC_SUBTREE="/reports/vimpatch/"
-  install_dependencies
-  clone_doc
-  clone_neovim
-  generate_vimpatch_report
-  commit_doc
-)
+is_ci_build? && {
+  install_jq
+}
+
+DOC_SUBTREE="/reports/vimpatch/"
+clone_doc
+clone_neovim
+generate_vimpatch_report
+commit_doc


### PR DESCRIPTION
Don't install unnecessary dependencies (e.g. jq, but not clang or doxygen for vimpatch report) to clean up the scripts and make builds a tiny bit faster.
