### PR TITLE
[RFC] Add coverity build type.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,17 @@ env:
   global:
     # Encrypted environment variables, see
     # http://docs.travis-ci.com/user/encryption-keys/
-    - secure: "OyoqXO0CqQJpxggE0tNi6LeYXGHslw4SSe4u3UbTOali5AbKdRnSxkMz9YQiuEajJDI2//LZef6RVLULFPZqzIOzsr4yi9S1fbPhXHvqtnZOkpamnkXNNCf7Fd6vGJtT1W140YR9woQoSk0bcLepawSdtkgp+n/ZSqY8rvADgqw="
+    #
+    # GH_TOKEN: Marvim's Github access token
+    - secure: OyoqXO0CqQJpxggE0tNi6LeYXGHslw4SSe4u3UbTOali5AbKdRnSxkMz9YQiuEajJDI2//LZef6RVLULFPZqzIOzsr4yi9S1fbPhXHvqtnZOkpamnkXNNCf7Fd6vGJtT1W140YR9woQoSk0bcLepawSdtkgp+n/ZSqY8rvADgqw=
+    # COVERITY_SCAN_TOKEN
+    - secure: pgI3Qt7bCRDeuKX38hP9xTJ6CdbwoUkcPToHnfDFYeclhUJRgCfZhCKKO+zTwqoa2Jx7wShoFeHaKidOFctg4ls4lrn47b0bPFED3LtU7RDQaeamqFKzgTV1IcEpkUfGl/i8tOmaEd7UvyUHKuKZmjmVr4Ce4ugATShYB186EW0=
   matrix:
-    - CI_TARGET=doxygen
     - CI_TARGET=clang-report
+    - CI_TARGET=coverity
+    - CI_TARGET=doc-index
+    - CI_TARGET=doxygen
     - CI_TARGET=translation-report
     - CI_TARGET=vimpatch-report
-    - CI_TARGET=doc-index
 script:
   - ./ci/${CI_TARGET}.sh

--- a/ci/coverity.sh
+++ b/ci/coverity.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -e
+
+BUILD_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source ${BUILD_DIR}/ci/common/common.sh
+source ${BUILD_DIR}/ci/common/neovim.sh
+
+COVERITY_BRANCH=${COVERITY_BRANCH:-master}
+
+trigger_coverity() {
+  cd ${NEOVIM_DIR}
+
+  wget -q -O - https://scan.coverity.com/scripts/travisci_build_coverity_scan.sh |
+    TRAVIS_BRANCH="${NEOVIM_BRANCH}" \
+    COVERITY_SCAN_PROJECT_NAME="${NEOVIM_REPO}" \
+    COVERITY_SCAN_NOTIFICATION_EMAIL="coverity@aktau.be" \
+    COVERITY_SCAN_BRANCH_PATTERN="${COVERITY_BRANCH}" \
+    COVERITY_SCAN_BUILD_COMMAND_PREPEND="${MAKE_CMD} deps" \
+    COVERITY_SCAN_BUILD_COMMAND="${MAKE_CMD} nvim" \
+    bash || echo "Running coverity script failed, ignoring."
+}
+
+clone_neovim
+trigger_coverity


### PR DESCRIPTION
Second attempt, this time with a more reviewable PR.

After merging this, @aktau (I think, based on `COVERITY_SCAN_NOTIFICATION_EMAIL`) would need to re-encrypt the coverity token for Travis:

``` bash
cd bot-ci
travis encrypt 'COVERITY_SCAN_TOKEN=<token>' -r neovim/bot-ci --add
```

We already have a `secret` entry containing `GH_TOKEN`, but this is not a problem:

> You may add multiple entries to your .travis.yml with key "secure." They will all be available to your program.

I don't have any way to really test this PR, unfortunately, but at least there are no syntax errors:

> $ ./ci/${CI_TARGET}.sh
> Cloning into '/home/travis/build/fwalch/bot-ci/build/neovim'...
> remote: Counting objects: 1948, done.
> remote: Compressing objects: 100% (1771/1771), done.
> remote: Total 1948 (delta 156), reused 1645 (delta 146)
> Receiving objects: 100% (1948/1948), 6.86 MiB | 13.46 MiB/s, done.
> Resolving deltas: 100% (156/156), done.
> Checking connectivity... done.
> Note: COVERITY_SCAN_PROJECT_NAME and COVERITY_SCAN_TOKEN are available on Project Settings page on scan.coverity.com
> ERROR: COVERITY_SCAN_TOKEN must be set
> Running coverity script failed, ignoring.
