### PR TITLE
[RFC] Update clang version.

### DIFF
--- a/ci/common/dependencies.sh
+++ b/ci/common/dependencies.sh
@@ -3,7 +3,7 @@
 require_environment_variable BUILD_DIR "${BASH_SOURCE[0]}" ${LINENO}
 
 DOXYGEN_VERSION=${DOXYGEN_VERSION:-1.8.7}
-CLANG_VERSION=${CLANG_VERSION:-3.4}
+CLANG_VERSION=${CLANG_VERSION:-3.5}
 
 # Define directories where dependencies are installed to
 DEPS_INSTALL_DIR=${DEPS_INSTALL_DIR:-${BUILD_DIR}/build/.deps}
@@ -24,13 +24,14 @@ install_clang() {
   mkdir -p ${DEPS_BIN_DIR}
 
   echo "Installing Clang ${CLANG_VERSION}..."
-  sudo add-apt-repository 'deb http://llvm.org/apt/precise/ llvm-toolchain-precise main'
+  sudo add-apt-repository "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu precise main"
+  sudo add-apt-repository "deb http://llvm.org/apt/precise/ llvm-toolchain-precise-${CLANG_VERSION} main"
   wget -q -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
   sudo apt-get update -qq
   sudo apt-get install -y -q clang-${CLANG_VERSION}
 
-  ln -fs /usr/bin/clang ${DEPS_BIN_DIR}
-  ln -fs /usr/bin/scan-build ${DEPS_BIN_DIR}
+  ln -fs /usr/bin/clang-${CLANG_VERSION} ${DEPS_BIN_DIR}/clang
+  ln -fs /usr/bin/scan-build-${CLANG_VERSION} ${DEPS_BIN_DIR}/scan-build
 }
 
 # For info on jq, see https://stedolan.github.io/jq


### PR DESCRIPTION
The build error discussed the end of #11 also occurred locally, but didn't happen when using another repo (there are a few available from http://llvm.org/apt).

I took this opportunity to update clang to 3.5, although that didn't change the number of warnings. The additional `ubuntu-toolchain-r` PPA was added because "gcc 4.8 backport (ppa) is necessary on Precise (for libstdc++)" (http://llvm.org/apt/).

[Build](https://travis-ci.org/fwalch/bot-ci/builds/35556187), [commit](https://github.com/fwalch/doc/commit/83b0fe50c57d5c73f00cc0a5ee87fa6a27d9d072), [![Clang Scan Build](https://fwalch.github.io/doc/reports/clang/badge.svg)](https://fwalch.github.io/doc/reports/clang)
