### PR TITLE
[RFC] Build nightly based on latest successful Travis build.

### DIFF
--- a/ci/common/neovim.sh
+++ b/ci/common/neovim.sh
@@ -8,6 +8,14 @@ NEOVIM_BRANCH=${NEOVIM_BRANCH:-master}
 
 clone_neovim() {
   rm -rf ${NEOVIM_DIR}
-  git clone --branch ${NEOVIM_BRANCH} --depth 1 git://github.com/${NEOVIM_REPO} ${NEOVIM_DIR}
-  NEOVIM_COMMIT=$(git --git-dir=${NEOVIM_DIR}/.git rev-parse HEAD)
+
+  if [[ -n "${NEOVIM_COMMIT}" ]]; then
+    # Fetch specific revision.
+    git clone --branch ${NEOVIM_BRANCH} --depth 50 git://github.com/${NEOVIM_REPO} ${NEOVIM_DIR}
+    git --git-dir=${NEOVIM_DIR}/.git reset --hard ${NEOVIM_COMMIT}
+  else
+    # Fetch latest revision of branch.
+    git clone --branch ${NEOVIM_BRANCH} --depth 1 git://github.com/${NEOVIM_REPO} ${NEOVIM_DIR}
+    NEOVIM_COMMIT=$(git --git-dir=${NEOVIM_DIR}/.git rev-parse HEAD)
+  fi
 }

--- a/ci/common/travis-api.sh
+++ b/ci/common/travis-api.sh
@@ -1,0 +1,10 @@
+# Send a non-authenticated request to the Travis API.
+# ${1}: API endpoint.
+send_travis_api_request() {
+  local endpoint="${1}"
+
+  curl -H "Accept: application/vnd.travis-ci.2+json" \
+    -X GET \
+    https://api.travis-ci.org/${endpoint} \
+    2>/dev/null
+}


### PR DESCRIPTION
Looks at the last 50 builds (from pushes, not PR builds) on `neovim/neovim` and searches the latest successful one on `master`, then builds the nightly from that.

I tested it with my Neovim fork. It is at current `neovim/neovim` master (65942d3a8d84510fcee2dd1c6306a5af13296c84), but its last successful Travis build points at 6e268cd0d40a3652a68b486bdbb421d39295ab48. This is the version used to [create](https://travis-ci.org/fwalch/bot-ci/jobs/39031280) the [nightly](https://github.com/fwalch/neovim/releases/nightly):

```
Using commit 6e268cd0d40a3652a68b486bdbb421d39295ab48 from latest successful Travis build on fwalch/neovim:master.
nightly tag does not point to 6e268cd0d40a3652a68b486bdbb421d39295ab48, continuing.
```
