### PR TITLE
[RFC] Auto-assign labels to PRs based on their title.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
     # COVERITY_SCAN_TOKEN
     - secure: pgI3Qt7bCRDeuKX38hP9xTJ6CdbwoUkcPToHnfDFYeclhUJRgCfZhCKKO+zTwqoa2Jx7wShoFeHaKidOFctg4ls4lrn47b0bPFED3LtU7RDQaeamqFKzgTV1IcEpkUfGl/i8tOmaEd7UvyUHKuKZmjmVr4Ce4ugATShYB186EW0=
   matrix:
+    - CI_TARGET=assign-labels
     - CI_TARGET=clang-report
     - CI_TARGET=coverity
     - CI_TARGET=doc-index

--- a/ci/assign-labels.sh
+++ b/ci/assign-labels.sh
@@ -1,0 +1,96 @@
+#!/bin/bash -e
+
+BUILD_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source ${BUILD_DIR}/ci/common/common.sh
+source ${BUILD_DIR}/ci/common/dependencies.sh
+source ${BUILD_DIR}/ci/common/github-api.sh
+source ${BUILD_DIR}/ci/common/neovim.sh
+
+TAGS=('[WIP]' '[RFC]' '[RDY]')
+LABELS=('WIP' 'RFC' 'RDY')
+DRY_RUN=${DRY_RUN:-false}
+
+label_issue() {
+  local issue_id="${1}"
+  local issue_labels="${2}"
+  local new_label="${3}"
+
+  # Modify existing labels, if any.
+  # Otherwise just use new label.
+  if [[ -n "${issue_labels}" ]]; then
+    issue_labels="\"${issue_labels//,/\",\"}\","
+
+    # Remove inapplicable labels, if any.
+    local i
+    for ((i=0; i < ${#LABELS[@]}; i=i+1)); do
+      local old_label="${LABELS[i]}"
+
+      if [[ "${issue_labels}" == *"${old_label}"* && "${old_label}" != "${new_label}" ]]; then
+        echo "  Removing '${old_label}' label."
+        issue_labels="${issue_labels/\"${old_label}\",/}"
+      fi
+    done
+    # Append new label to existing ones.
+    issue_labels="${issue_labels}\"${new_label}\""
+  else
+    issue_labels="\"${new_label}\""
+  fi
+
+  if [[ ${DRY_RUN} != true ]]; then
+    send_gh_api_data_request repos/${NEOVIM_REPO}/issues/${issue_id} \
+      PATCH \
+      "{\"labels\": [${issue_labels}]}" \
+      > /dev/null
+  fi
+}
+
+check_issue() {
+  local issue_id="${1}"
+  local issue_name="${2}"
+  local issue_labels="${3}"
+
+  # Check if issue title is prefixed with any of the tags.
+  local i
+  for ((i=0; i < ${#TAGS[@]}; i=i+1)); do
+    local tag="${TAGS[i]}"
+    local new_label="${LABELS[i]}"
+
+    if [[ "${issue_name}" == "${tag}"* ]]; then
+      # Check if issue is already labelled correctly.
+      if [[ "${issue_labels}" != *"${new_label}"* ]]; then
+        echo "Updating ${tag} issue ${issue_id}."
+        echo "  Adding '${new_label}' label."
+
+        label_issue "${issue_id}" "${issue_labels}" "${new_label}"
+      fi
+      break
+    fi
+  done
+}
+
+assign_labels() {
+  local page
+  for ((page=1; ; page=page+1)); do
+    local issues
+    readarray -t issues < <( \
+      send_gh_api_request "repos/${NEOVIM_REPO}/issues?sort=created&per_page=100&page=${page}" \
+      | jq -r -c 'map(select(.pull_request?)) | .[] | .number, .title, (.labels | map(.name) | join(","))') \
+      || exit
+
+    # Abort if no more issues returned from API.
+    if [[ -z "${issues}" ]]; then
+      break
+    fi
+
+    local i
+    for ((i=0; i < ${#issues[@]}; i=i+3)); do
+      check_issue "${issues[i]}" "${issues[i+1]}" "${issues[i+2]}"
+    done
+  done
+}
+
+is_ci_build && {
+  install_jq
+}
+
+assign_labels

--- a/ci/common/github-api.sh
+++ b/ci/common/github-api.sh
@@ -19,6 +19,7 @@ send_gh_api_request() {
   local verb="${2:-GET}"
 
   local response="$(curl -H "Accept: application/vnd.github.v3+json" \
+    -H "User-Agent: neovim/bot-ci" \
     -u "${GH_TOKEN}:x-oauth-basic" \
     -X ${verb} \
     https://api.github.com/${endpoint} \
@@ -36,6 +37,7 @@ send_gh_api_data_request() {
   local data="${3}"
 
   local response="$(curl -H "Accept: application/vnd.github.v3+json" \
+    -H "User-Agent: neovim/bot-ci" \
     -u "${GH_TOKEN}:x-oauth-basic" \
     -X ${verb} \
     -d "${data}" \
@@ -57,6 +59,7 @@ upload_release_asset() {
   local mime_type="$(mimetype --output-format '%m' "${file}")"
 
   local response="$(curl -H "Accept: application/vnd.github.v3+json" \
+    -H "User-Agent: neovim/bot-ci" \
     -H "Content-Type: ${mime_type}" \
     -u "${GH_TOKEN}:x-oauth-basic" \
     -T "${file}"\


### PR DESCRIPTION
## Update:

See https://github.com/neovim/bot-ci/pull/28#issuecomment-62583352
### Initial content:

Testing with different repos:

``` bash
$ export GH_TOKEN=... # valid token unfortunately required if you want to test without modifying the source
$ NEOVIM_REPO=fwalch/neovim SIMULATE=true ./ci/assign-labels.sh
Local build, skip installing dependencies.
Processing only PRs.
Updating [RDY] issue 5.
  Adding 'ready' label.
  Removing 'in progress' label.
$ NEOVIM_REPO=fwalch/neovim SIMULATE=true PROCESS_ONLY_PRS=false ./ci/assign-labels.sh
Local build, skip installing dependencies.
Updating [RDY] issue 5.
  Adding 'ready' label.
  Removing 'in progress' label.
Updating [RDY] issue 4.
  Adding 'ready' label.
$ NEOVIM_REPO=neovim/neovim SIMULATE=true ./ci/assign-labels.sh
Local build, skip installing dependencies.
Processing only PRs.
Updating [RFC] issue 1414.
  Adding 'in progress' label.
Updating [RFC] issue 1411.
  Adding 'in progress' label.
Updating [RFC] issue 1403.
  Adding 'in progress' label.
Updating [RFC] issue 1399.
  Adding 'in progress' label.
Updating [RFC] issue 1391.
  Adding 'in progress' label.
Updating [RFC] issue 1389.
  Adding 'in progress' label.
Updating [RFC] issue 1383.
  Adding 'in progress' label.
Updating [RFC] issue 1373.
  Adding 'in progress' label.
```

Only thing left to decide is whether all issues or just PRs should be processed, then I'll probably remove that option. I thought about splitting the code into multiple functions to improve readability, but didn't do so for now.

I didn't find a way to get more than 30 issues from the Github API.

Ping @elmart.
