### PR TITLE
[RFC] Show output during clang report generation.

### DIFF
--- a/ci/clang-report.sh
+++ b/ci/clang-report.sh
@@ -17,7 +17,8 @@ generate_clang_report() {
     --use-analyzer=$(which clang) \
     --html-title="Neovim Static Analysis Report" \
     -o build/clang-report \
-    ${MAKE_CMD} > ${BUILD_DIR}/scan-build.out
+    ${MAKE_CMD} \
+    | tee ${BUILD_DIR}/scan-build.out
 
   # Copy to doc repository
   rm -rf ${DOC_DIR}/reports/clang


### PR DESCRIPTION
The last clang report build failed; looks like something doesn't work with current `neovim/neovim`, or maybe it just takes too much time and Travis times out. In either case, this should give us a clue of what's wrong. It basically prints _and_ writes the output of scan-build to a file.

Build is at https://travis-ci.org/fwalch/bot-ci/jobs/40486113
