### PR TITLE
[RFC] Travis: Allow Coverity to fail.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ env:
     - CI_TARGET=translation-report
     - CI_TARGET=user-docu
     - CI_TARGET=vimpatch-report
+matrix:
+  allow_failures:
+    - env: CI_TARGET=coverity
 script:
   - ./ci/${CI_TARGET}.sh
 notifications:

--- a/ci/coverity.sh
+++ b/ci/coverity.sh
@@ -28,7 +28,7 @@ trigger_coverity() {
     COVERITY_SCAN_BRANCH_PATTERN="${COVERITY_BRANCH}" \
     COVERITY_SCAN_BUILD_COMMAND_PREPEND="${MAKE_CMD} deps" \
     COVERITY_SCAN_BUILD_COMMAND="${MAKE_CMD} nvim" \
-    bash || echo "Running coverity script failed, ignoring."
+    bash
 }
 
 is_date_ok && {


### PR DESCRIPTION
That way we still know that something went wrong, but it doesn't fail the whole build.
