### PR TITLE
[RFC] Fix clang empty report showed when warnings present.

### DIFF
--- a/ci/clang-report.sh
+++ b/ci/clang-report.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
+set -o pipefail
 
 BUILD_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source ${BUILD_DIR}/ci/common/common.sh


### PR DESCRIPTION
Problem  : Empty error is being showed even if there are warnings.
Cause    : scan-build --status-bugs is working, but checked status is
           that of the pipe, not scan-build's one.
Solution : Set option `pipefail` so that pipe status is that of the last
           failing command.
