### PR TITLE
deps: send DEPS_PREFIX to cmake

### DIFF
--- a/ci/common/deps-repo.sh
+++ b/ci/common/deps-repo.sh
@@ -49,7 +49,7 @@ build_deps() {
   depsdir=${depsdir%/*}
   rm -rf ${depsdir}
   cd ${NEOVIM_DIR}
-  make deps DEPS_CMAKE_FLAGS="-DDEPS_DIR=${depsdir} ${2}"
+  make deps DEPS_CMAKE_FLAGS="-DDEPS_PREFIX=${depsdir} ${2}"
   rm -rf ${depsdir}/build
 }
 


### PR DESCRIPTION
DEPS_DIR was replaced with DEPS_PREFIX by
https://github.com/neovim/neovim/pull/1588
