### PR TITLE
[RFC] Travis: Use container-based infrastructure where possible.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: c
 os:
   - linux
+sudo: false
 env:
   global:
     # Encrypted environment variables, see
@@ -12,14 +13,10 @@ env:
     - secure: pgI3Qt7bCRDeuKX38hP9xTJ6CdbwoUkcPToHnfDFYeclhUJRgCfZhCKKO+zTwqoa2Jx7wShoFeHaKidOFctg4ls4lrn47b0bPFED3LtU7RDQaeamqFKzgTV1IcEpkUfGl/i8tOmaEd7UvyUHKuKZmjmVr4Ce4ugATShYB186EW0=
   matrix:
     - CI_TARGET=assign-labels
-    - CI_TARGET=clang-report
     - CI_TARGET=coverity
     - CI_TARGET=doc-index
     - CI_TARGET=doxygen
     - CI_TARGET=nightly
-    - CI_TARGET=deps32
-    - CI_TARGET=deps64
-    - CI_TARGET=translation-report
     - CI_TARGET=user-docu
     - CI_TARGET=vimpatch-report
 matrix:
@@ -27,6 +24,15 @@ matrix:
     - os: osx
       env: CI_TARGET=deps64
       compiler: gcc-4.9
+      sudo: true
+    - env: CI_TARGET=clang-report
+      sudo: true
+    - env: CI_TARGET=deps32
+      sudo: true
+    - env: CI_TARGET=deps64
+      sudo: true
+    - env: CI_TARGET=translation-report
+      sudo: true
   allow_failures:
     - env: CI_TARGET=coverity
 install:


### PR DESCRIPTION
Information on the container-based infrastructure is [here](http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/).

See [here](https://travis-ci.org/fwalch/bot-ci/builds/46571477) for a test build. The failing job is the OS X `deps64` build (because OS X is not enabled on my fork). If you look at the job detail pages, you'll see the differences between the old (`sudo: true`) and the new (`sudo: false`) builds.

There might be a problem with the OS X build (https://github.com/travis-ci/travis-ci/issues/2957), but unfortunately I have no way to test this. So I'd suggest just merging this and reverting if it doesn't work out.

To do: try to activate caching for the repositories that most of these jobs clone (`neovim/neovim`, `neovim/doc`, ...). Edit: I'd actually leave that for a later PR; if this doesn't work with OS X, it doesn't make sense to continue.