### PR TITLE
[RFC] deps: Don't pass unused CMake variable.

### DIFF
--- a/ci/common/deps-repo.sh
+++ b/ci/common/deps-repo.sh
@@ -50,13 +50,11 @@ build_deps() {
   rm -rf ${depsdir}
   mkdir ${depsdir}
 
-  #build deps in non-default location...
-  #  https://github.com/neovim/neovim/pull/1588#issuecomment-66778849
   cd ${depsdir}
-  cmake -DDEPS_PREFIX=${depsdir} ${2} ${NEOVIM_DIR}/third-party/
+  cmake ${2} ${NEOVIM_DIR}/third-party/
   make
 
-  rm -rf ${depsdir}/{build,CMakeFiles,CMakeCache.txt,cmake_install.cmake,Makefile,.third-party}
+  rm -rf ./{build,CMakeFiles,CMakeCache.txt,cmake_install.cmake,Makefile,.third-party}
 }
 
 # Clone Neovim deps repo.


### PR DESCRIPTION
DEPS_PREFIX is only required to build Neovim with a custom dependencies directory,
not for building the dependencies themselves.

Fixes a CMake warning:

```
CMake Warning:
Manually-specified variables were not used by the project:
DEPS_PREFIX
```