### PR TITLE
[RFC] Push dependency sources to neovim/deps.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
     - CI_TARGET=assign-labels
     - CI_TARGET=clang-report
     - CI_TARGET=coverity
+    - CI_TARGET=deps-src
     - CI_TARGET=deps32
     - CI_TARGET=deps64
     - CI_TARGET=doc-index

--- a/ci/common/deps-repo.sh
+++ b/ci/common/deps-repo.sh
@@ -18,6 +18,12 @@ DEPS_OSX64_BRANCH=${DEPS_OSX64_BRANCH:-${DEPS_BRANCH:-master}}
 DEPS_OSX64_DIR=${DEPS_OSX64_DIR:-${DEPS_DIR:-/opt/neovim-deps}}
 DEPS_OSX64_SUBTREE=${DEPS_OSX64_SUBTREE:-/osx-x64/}
 
+# Dependencies source code
+DEPS_SRC_REPO=${DEPS_SRC_REPO:-${DEPS_REPO:-neovim/deps}}
+DEPS_SRC_BRANCH=${DEPS_SRC_BRANCH:-${DEPS_BRANCH:-master}}
+DEPS_SRC_DIR=${DEPS_SRC_DIR:-${DEPS_DIR:-/opt/neovim-deps}}
+DEPS_SRC_SUBTREE=${DEPS_SRC_SUBTREE:-/src/}
+
 # Set up prebuilt 64-bit Neovim dependencies.
 setup_deps64() {
   local deps_dir="DEPS_${CI_OS^^}64_DIR"

--- a/ci/deps-src.sh
+++ b/ci/deps-src.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -e
+
+BUILD_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "${BUILD_DIR}/ci/common/common.sh"
+source "${BUILD_DIR}/ci/common/neovim.sh"
+source "${BUILD_DIR}/ci/common/deps-repo.sh"
+
+DEPS_SRC_BUILD_DIR=${DEPS_SRC_BUILD_DIR:-${BUILD_DIR}/build/deps-src}
+
+clone_deps-src() {
+  clone_deps DEPS_SRC
+}
+
+extract_sources() {
+  rm -rf "${DEPS_SRC_BUILD_DIR}"
+  mkdir -p "${DEPS_SRC_BUILD_DIR}"
+
+  echo "Building dependencies."
+  cd "${DEPS_SRC_BUILD_DIR}"
+  # Disable dependencies only required for tests
+  cmake -DUSE_BUNDLED_BUSTED=OFF "${NEOVIM_DIR}/third-party/"
+  make
+
+  echo "Extracting sources."
+  cd "${DEPS_SRC_BUILD_DIR}/build/src"
+  rm -rf ./*-{stamp,build}
+  while read dir; do
+    cd "${DEPS_SRC_BUILD_DIR}/build/src/${dir}"
+    echo "Cleaning ${dir}."
+    rm -rf autom4te.cache
+    make clean || true
+    make distclean || true
+  done <<< "$(find . -maxdepth 1 -mindepth 1 -type d -printf '%f\n')"
+
+  # Move into cloned repo's path for committing.
+  rm -rf "${DEPS_SRC_DIR%/}/${DEPS_SRC_SUBTREE%/}"/*
+  mv "${DEPS_SRC_BUILD_DIR}/build/src"/* "${DEPS_SRC_DIR%/}/${DEPS_SRC_SUBTREE}"
+}
+
+commit_deps-src() {
+  commit_subtree DEPS_SRC
+}
+
+clone_deps-src
+clone_neovim
+
+extract_sources
+commit_deps-src


### PR DESCRIPTION
Added a new build that pushes the sources of the built-in dependencies
to neovim/deps.

This is useful for the Ubuntu PPA, where the sources cannot be
downloaded during the build (no internet connections allowed) and thus
must already be present beforehand. Currently, this is done by manually
updating a Launchpad repository every time one of Neovim's builtin
dependencies is updated (https://code.launchpad.net/~neovim-ppa/neovim-ppa/neovim-deps).

Before this is merged, the `src` folder needs to be manually created in `neovim/deps`.

It's a bit of a workaround, since we compile all dependencies and remove the build output afterwards just to get the sources, but on the upside we don't commit sources that won't compile.

ping @justinmk