### PR TITLE
[RFC] Add bzr-git sync for libvterm/libtermkey mirrors.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,12 @@ env:
     - CI_TARGET=assign-labels
     - CI_TARGET=clang-report
     - CI_TARGET=coverity
+    - CI_TARGET=deps32
+    - CI_TARGET=deps64
     - CI_TARGET=doc-index
     - CI_TARGET=doxygen
     - CI_TARGET=nightly
-    - CI_TARGET=deps32
-    - CI_TARGET=deps64
+    - CI_TARGET=sync-mirrors
     - CI_TARGET=translation-report
     - CI_TARGET=user-docu
     - CI_TARGET=vimpatch-report

--- a/ci/common/common.sh
+++ b/ci/common/common.sh
@@ -113,18 +113,17 @@ commit_subtree() {(
     git config --local user.name ${GIT_NAME}
     git config --local user.email ${GIT_EMAIL}
 
-    git commit -m "${CI_TARGET//-/ }: Automatic update." && {
-      until (git pull --rebase git://github.com/${!repo} ${!branch} &&
-             git push https://${GH_TOKEN}@github.com/${!repo} ${!branch} >/dev/null 2>&1 &&
-             echo "Pushed to ${!repo} ${!branch}."); do
-        echo "Retry pushing to ${!repo} ${!branch}."
-        sleep 1
-      done
-    } || echo "No changes for ${CI_TARGET//-/ }."
+    git commit -m "${CI_TARGET//-/ }: Automatic update." || true
+    until (git pull --rebase git://github.com/${!repo} ${!branch} &&
+           git push https://${GH_TOKEN}@github.com/${!repo} ${!branch} >/dev/null 2>&1 &&
+           echo "Pushed to ${!repo} ${!branch}."); do
+      echo "Retry pushing to ${!repo} ${!branch}."
+      sleep 1
+    done
     return
-  } || prompt_key_local "Build finished, do you want to commit and push the results to ${!repo} ${!branch} (change by setting ${repo}/${branch})?" && {
+  } || prompt_key_local "Build finished, do you want to commit and push the results to ${!repo}:${!branch} (change by setting ${repo}/${branch})?" && {
     # Commit in local builds.
-    git commit
+    git commit || true
     git push ssh://git@github.com/${!repo} ${!branch}
   }
 )}

--- a/ci/common/dependencies.sh
+++ b/ci/common/dependencies.sh
@@ -46,3 +46,11 @@ install_gcc_multilib() {
   ln -fs ${DEPS_BIN_DIR}/gcc ${DEPS_BIN_DIR}/cc
   ln -fs ${DEPS_BIN_DIR}/g++ ${DEPS_BIN_DIR}/c++
 }
+
+install_git_bzr() {
+  echo "Installing git-bzr-ng..."
+  sudo add-apt-repository "deb http://ppa.launchpad.net/fwalch/git-bzr-ng/ubuntu precise main"
+  sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys AF82DF84
+  sudo apt-get update -qq
+  sudo apt-get install -y -q git-bzr-ng
+}

--- a/ci/sync-mirrors.sh
+++ b/ci/sync-mirrors.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -e
+set -o pipefail
+
+BUILD_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "${BUILD_DIR}/ci/common/common.sh"
+source "${BUILD_DIR}/ci/common/dependencies.sh"
+
+WORK_DIR=${WORK_DIR:-${BUILD_DIR}/build}
+MIRROR_USER=${MIRROR_USER:-neovim}
+MIRROR_BRANCH=${MIRROR_BRANCH:-master}
+
+sync_bzr_mirror() {
+  local repo="${1}"
+  local mirror_url="git://github.com/${MIRROR_USER}/${repo}.git"
+  local upstream_url="http://bazaar.leonerd.org.uk/c/${repo}"
+  local repo_dir="${WORK_DIR}/${repo}"
+
+  echo "Cloning Git mirror repo ${mirror_url}:${MIRROR_BRANCH} into ${repo_dir}."
+  rm -rf "${repo_dir}"
+  git clone --branch "${MIRROR_BRANCH}" --depth 1 "${mirror_url}" "${repo_dir}"
+
+  (
+    cd "${repo_dir}"
+    echo "Importing ${upstream_url} into Git branch ${repo}-import."
+    git bzr import "${upstream_url}" "${repo}-import"
+
+    echo "Fast-forwarding ${MIRROR_BRANCH} to ${repo}-import."
+    git merge --ff-only "${repo}-import"
+  )
+
+  echo "Pushing to ${MIRROR_USER}/${repo}."
+  MIRROR_SUBTREE="/" \
+  MIRROR_DIR="${repo_dir}" \
+  MIRROR_REPO="${MIRROR_USER}/${repo}" \
+  commit_subtree MIRROR
+}
+
+is_ci_build && {
+  install_git_bzr
+}
+
+sync_bzr_mirror libvterm
+sync_bzr_mirror libtermkey


### PR DESCRIPTION
Fortunately each import produces the exact same Git commits (same hash).

Output from local run:

```
Local build, skip installing dependencies.
Cloning Git mirror repo git://github.com/neovim/libvterm.git:master into /home/florian/Projects/bot-ci/build/libvterm.
Cloning into '/home/florian/Projects/bot-ci/build/libvterm'...
remote: Counting objects: 72, done.
remote: Compressing objects: 100% (63/63), done.
remote: Total 72 (delta 9), reused 56 (delta 8), pack-reused 0
Receiving objects: 100% (72/72), 71.34 KiB | 6.00 KiB/s, done.
Resolving deltas: 100% (9/9), done.
Checking connectivity... done.
Importing http://bazaar.leonerd.org.uk/c/libvterm into Git branch libvterm-import.
Branched 646 revisions.tching revisions:Finishing stream:Done 6952/69526952
23:10:21 Calculating the revisions to include ...
23:10:21 Starting export of 675 revisions ...
23:10:22 Exported 675 revision(s) in 0:00:01
Fast-forwarding master to libvterm-import.
Updating 20ad139..6d2f0be
Fast-forward
Makefile               | 14 ++++++++------
doc/seqs.txt           |  5 ++++-
src/parser.c           | 22 +++++++++++-----------
src/pen.c              |  6 +++---
src/screen.c           |  8 +++++---
src/state.c            | 13 +++++++++----
src/vterm.c            |  2 +-
src/vterm_internal.h   |  6 ++++++
t/43screen_resize.test | 15 +++++++++++++++
9 files changed, 62 insertions(+), 29 deletions(-)
Pushing to neovim/libvterm.
Build finished, do you want to commit and push the results to neovim/libvterm:master (change by setting MIRROR_REPO/MIRROR_BRANCH)?
Press a key to continue, CTRL-C to abort...
```

Test build using `fwalch/libtermkey` and `fwalch/libvterm`: https://travis-ci.org/fwalch/bot-ci/builds/68218196