### PR TITLE
[RFC] Coverity: Show contents of scm_log.txt.

### DIFF
--- a/ci/coverity.sh
+++ b/ci/coverity.sh
@@ -2,10 +2,11 @@
 set -e
 
 BUILD_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-source ${BUILD_DIR}/ci/common/common.sh
-source ${BUILD_DIR}/ci/common/neovim.sh
+source "${BUILD_DIR}/ci/common/common.sh"
+source "${BUILD_DIR}/ci/common/neovim.sh"
 
 COVERITY_BRANCH=${COVERITY_BRANCH:-master}
+COVERITY_LOG_FILE="${BUILD_DIR}/build/neovim/cov-int/scm_log.txt"
 
 # Check day of week to run Coverity only on Monday, Wednesday, Friday, and Saturday.
 is_date_ok() {
@@ -21,7 +22,7 @@ is_date_ok() {
 trigger_coverity() {
   require_environment_variable NEOVIM_DIR "${BASH_SOURCE[0]}" ${LINENO}
 
-  cd ${NEOVIM_DIR}
+  cd "${NEOVIM_DIR}"
   wget -q -O - https://scan.coverity.com/scripts/travisci_build_coverity_scan.sh |
     TRAVIS_BRANCH="${NEOVIM_BRANCH}" \
     COVERITY_SCAN_PROJECT_NAME="${NEOVIM_REPO}" \
@@ -30,6 +31,11 @@ trigger_coverity() {
     COVERITY_SCAN_BUILD_COMMAND_PREPEND="${MAKE_CMD} deps" \
     COVERITY_SCAN_BUILD_COMMAND="${MAKE_CMD} nvim" \
     bash
+
+  if [[ -f "${COVERITY_LOG_FILE}" ]]; then
+    echo "Contents of ${COVERITY_LOG_FILE}:"
+    cat "${COVERITY_LOG_FILE}"
+  fi
 }
 
 is_date_ok && {


### PR DESCRIPTION
Warning on Travis:

    [WARNING] Unable to gather all SCM data - see log at
    /home/travis/build/neovim/bot-ci/build/neovim/cov-int/scm_log.txt
    for details.