### PR TITLE
[RFC] Clang report: Split into `make deps` and `make`.

### DIFF
--- a/ci/clang-report.sh
+++ b/ci/clang-report.sh
@@ -13,9 +13,12 @@ source ${BUILD_DIR}/ci/common/html.sh
 generate_clang_report() {
   cd ${NEOVIM_DIR}
 
-  # Generate static analysis report
   mkdir -p build/clang-report
 
+  # Compile deps
+  ${MAKE_CMD} deps
+
+  # Generate report
   if "${SCAN_BUILD:-scan-build}" \
       --status-bugs \
       --html-title="Neovim Static Analysis Report" \


### PR DESCRIPTION
If `make deps` is run through scan-build, warnings for
third-party dependencies will show up in the Clang report.