### PR TITLE
coverity: Use GCC 4.9.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,16 +25,19 @@ env:
     - CI_TARGET=clint-errors
 matrix:
   include:
-    - env: CI_TARGET=clang-report SCAN_BUILD=scan-build-3.6
+    - os: linux
+      env: CI_TARGET=clang-report SCAN_BUILD=scan-build-3.6
       compiler: clang-3.6
     - os: osx
       env: CI_TARGET=deps64
       compiler: clang
-    - env: CI_TARGET=coverity
-      compiler: gcc
+    - os: linux
+      env: CI_TARGET=coverity
+      compiler: gcc-4.9
   allow_failures:
-    - env: CI_TARGET=coverity
-      compiler: gcc
+    - os: linux
+      env: CI_TARGET=coverity
+      compiler: gcc-4.9
 install:
   - if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
       brew install bash;
@@ -47,23 +50,22 @@ addons:
       - llvm-toolchain-precise-3.6
       - ubuntu-toolchain-r-test
     packages:
-      # Basic Neovim/test dependencies.
       - autoconf
       - automake
       - build-essential
+      - bzr-fastimport
+      - clang-3.6
       - cmake
+      - g++-4.9
+      - g++-5
+      - gcc-4.9
+      - gcc-5
       - gdb
       - libtool
+      - llvm-3.6-dev
       - pkg-config
       - unzip
       - xclip
-      # Additional compilers/tools.
-      - clang-3.6
-      - g++-5
-      - gcc-5
-      - llvm-3.6-dev
-      # Tools required for bot-ci.
-      - bzr-fastimport
 cache:
   apt: true
   directories:


### PR DESCRIPTION
@justinmk 

For whatever reason, the coverity job does not install the APT packages.. `Adding APT Sources (BETA)` is missing from the build log.