### PR TITLE
Use Clang 3.7 for static analysis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,8 @@ env:
 matrix:
   include:
     - os: linux
-      env: CI_TARGET=clang-report SCAN_BUILD=scan-build-3.6
-      compiler: clang-3.6
+      env: CI_TARGET=clang-report SCAN_BUILD=scan-build-3.7
+      compiler: clang-3.7
     - os: osx
       env: CI_TARGET=deps64
       compiler: clang
@@ -47,14 +47,14 @@ script:
 addons:
   apt:
     sources:
-      - llvm-toolchain-precise-3.6
+      - llvm-toolchain-precise-3.7
       - ubuntu-toolchain-r-test
     packages:
       - autoconf
       - automake
       - build-essential
       - bzr-fastimport
-      - clang-3.6
+      - clang-3.7
       - cmake
       - g++-4.9
       - g++-5
@@ -62,7 +62,7 @@ addons:
       - gcc-5
       - gdb
       - libtool
-      - llvm-3.6-dev
+      - llvm-3.7-dev
       - pkg-config
       - unzip
       - xclip


### PR DESCRIPTION
Trying to get a test build on my repos running (fails with some luarocks issue currently).. locally, I get 8 issues in the static analysis output. The clang report on the website shows only 2 issues, but I don't have a Clang 3.6 locally to compare.