### PR TITLE
travis: remove LLVM apt PPA; fallback to clang 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,8 @@ env:
 matrix:
   include:
     - os: linux
-      env: CI_TARGET=clang-report SCAN_BUILD=scan-build-3.6
-      compiler: clang-3.6
+      env: CI_TARGET=clang-report SCAN_BUILD=scan-build
+      compiler: clang
     - os: osx
       env: CI_TARGET=deps64
       compiler: clang
@@ -47,14 +47,13 @@ script:
 addons:
   apt:
     sources:
-      - llvm-toolchain-precise-3.6
       - ubuntu-toolchain-r-test
     packages:
       - autoconf
       - automake
       - build-essential
       - bzr-fastimport
-      - clang-3.6
+      - clang-3.4
       - cmake
       - g++-4.9
       - g++-5
@@ -62,7 +61,7 @@ addons:
       - gcc-5
       - gdb
       - libtool
-      - llvm-3.6-dev
+      - llvm-3.4-dev
       - pkg-config
       - unzip
       - xclip


### PR DESCRIPTION
References https://github.com/neovim/neovim/pull/4859