### PR TITLE
with_token: Use $token to perform replacement of '%token%' literal

### DIFF
--- a/ci/common/common.sh
+++ b/ci/common/common.sh
@@ -171,8 +171,9 @@ with_token() {
       set -u
       : ${GH_TOKEN}
     fi
+    token='%token%'
     for arg ; do
-      arg="${arg//%token%/$GH_TOKEN}"
+      arg="${arg//$token/$GH_TOKEN}"
       printf '%s\0' "$arg"
     done | xargs -0 -n 5000 -x sh -c '"$@"' - >&2 | sed "s/$GH_TOKEN/GH_TOKEN/g"
     return "${PIPESTATUS[1]}"


### PR DESCRIPTION
The ${var//pattern/repl} form of parameter expansion interprets a
leading % as anchoring pattern at the end of $var.  This broke the
github-api functions because they need to replace "%token%" inside
"%token%:x-oauth-basic", which doesn't match at the end.

Using a variable as the pattern avoids interpreting % as an anchor,
instead treating the text as a literal string.

Thanks to @blueyed for the debug build in #103, which helped track this down.