### PR TITLE
Use clang as a compiler for PVS reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,11 @@ env:
     - CI_TARGET=user-docu
     - CI_TARGET=vimpatch-report
     - CI_TARGET=clint-errors
-    - CI_TARGET=pvs-report
 matrix:
   include:
+    - os: linux
+      env: CI_TARGET=pvs-report
+      compiler: clang
     - os: linux
       env: CI_TARGET=clang-report SCAN_BUILD=scan-build-4.0
       compiler: clang-4.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
   include:
     - os: linux
       env: CI_TARGET=pvs-report
-      compiler: clang
+      compiler: clang-4.0
     - os: linux
       env: CI_TARGET=clang-report SCAN_BUILD=scan-build-4.0
       compiler: clang-4.0

--- a/ci/pvs-report.sh
+++ b/ci/pvs-report.sh
@@ -35,8 +35,8 @@ generate_pvs_report() {
   (
     cd "$NEOVIM_DIR"
 
-    sh ./scripts/pvscheck.sh --pvs detect --pvs-install .
-    sh ./scripts/pvscheck.sh --deps --recheck .
+    sh ./scripts/pvscheck.sh --environment-cc --pvs detect --pvs-install .
+    sh ./scripts/pvscheck.sh --environment-cc --deps --recheck .
 
     # Note: will also copy a binary log with *all* errors, including filtered
     # out. This is intentional.


### PR DESCRIPTION
Maybe this will make v677 warnings go away.