### PR TITLE
Remove unnecessary eval

### DIFF
--- a/ci/common/common.sh
+++ b/ci/common/common.sh
@@ -7,7 +7,7 @@
 # ${3}: Line number.
 require_environment_variable() {
   local variable_name="${1}"
-  local variable_content="${${variable_name}:-}"
+  local variable_content="${variable_name:-}"
   # shellcheck disable=2154
   if [[ -z "${variable_content}" ]]; then
     >&2 echo "${variable_name} not set at ${2}:${3}, cannot continue!"

--- a/ci/common/common.sh
+++ b/ci/common/common.sh
@@ -7,7 +7,7 @@
 # ${3}: Line number.
 require_environment_variable() {
   local variable_name="${1}"
-  eval "local variable_content=\"\${${variable_name}:-}\""
+  local variable_content="${${variable_name}:-}"
   # shellcheck disable=2154
   if [[ -z "${variable_content}" ]]; then
     >&2 echo "${variable_name} not set at ${2}:${3}, cannot continue!"

--- a/scripts/travis-setup.sh
+++ b/scripts/travis-setup.sh
@@ -23,7 +23,7 @@ _setup_deps() {
   export NVIM_DEPS_PREFIX="${1}/usr"
   echo "\$NVIM_DEPS_PREFIX: \"${NVIM_DEPS_PREFIX}\""
 
-  eval "$(${NVIM_DEPS_PREFIX}/bin/luarocks path)"
+  "$(${NVIM_DEPS_PREFIX}/bin/luarocks path)"
   echo "\$LUA_PATH: \"${LUA_PATH}\""
   echo "\$LUA_CPATH: \"${LUA_CPATH}\""
 


### PR DESCRIPTION
Removes an unnecessary call to eval from the travis-setup.sh file.

EDIT: Removed another eval from the common.sh file.