### PR TITLE
travis: Remove versioned clang/scan-build names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,24 +31,10 @@ matrix:
     - env: CI_TARGET=clint-errors
     - os: linux
       env: CI_TARGET=pvs-report
-      compiler: clang-4.0
-      addons:
-        apt:
-          sources:
-            - llvm-toolchain-trusty-4.0
-          packages:
-            - clang-4.0
-            - llvm-4.0-dev
+      compiler: clang
     - os: linux
-      env: CI_TARGET=clang-report SCAN_BUILD=scan-build-4.0
-      compiler: clang-4.0
-      addons:
-        apt:
-          sources:
-            - llvm-toolchain-trusty-4.0
-          packages:
-            - clang-4.0
-            - llvm-4.0-dev
+      env: CI_TARGET=clang-report SCAN_BUILD=scan-build
+      compiler: clang
     - os: osx
       env: CI_TARGET=nightly
       compiler: clang


### PR DESCRIPTION
Travis is providing clang >= 5.0 natively in the build environment, so
there's no need to install/run the tools from apt.llvm.org

Closes #125