### PR TITLE
Generate badge *after* generating the report

### DIFF
--- a/ci/pvs-report.sh
+++ b/ci/pvs-report.sh
@@ -57,8 +57,8 @@ generate_pvs_report() {
 main() {
   clone_doc
   clone_neovim
-  download_pvs_badge
   generate_pvs_report
+  download_pvs_badge
   commit_doc
 }
 


### PR DESCRIPTION
For some reason PVS badge is no longer available, courtesy of 8ce3331 commit 
which reordered functions.