### PR TITLE
deps-src: Keep <proj>-stamp directory, but remove post-patch stamp files

### DIFF
--- a/ci/deps-src.sh
+++ b/ci/deps-src.sh
@@ -24,7 +24,8 @@ extract_sources() {
 
   echo "Extracting sources."
   cd "${DEPS_SRC_BUILD_DIR}/build/src"
-  rm -rf ./*-{stamp,build}
+  rm -rf ./*-build
+  rm -f ./*-stamp/*-{configure,build,install,done}
   while read dir; do
     cd "${DEPS_SRC_BUILD_DIR}/build/src/${dir}"
     echo "Cleaning ${dir}."


### PR DESCRIPTION
The main steps of the ExternalProject build are, in order: mkdir,
download, update/patch, configure, build, install, done.  Since the
source directories are already patched, builds will fail if they try to
re-apply the patches.

We already run the (dist)clean targets for each project, so it should be
safe to run everything after the patch step of the ExternalProject
machinery.

---
Re-running the patch step has been causing the unstable PPA builds to [fail]
since https://github.com/neovim/neovim/pull/9123 was merged.

[fail]: https://launchpadlibrarian.net/393434904/buildlog_ubuntu-xenial-amd64.neovim_0.3.0~ubuntu1+git201810152021-8fd092f-479a1d0-04beb04~ubuntu16.04.1_BUILDING.txt.gz