### PR TITLE
Travis/macOS: update xcode to match Nvim project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,6 @@ install:
   - if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
       brew install bash;
       brew install jq;
-      brew install libtool;
     fi;
     printf "machine github.com login ${GH_TOKEN:-unknown} password x-oauth-basic\n" >> "$HOME/.netrc";
     printf "machine api.github.com login ${GH_TOKEN:-unknown} password x-oauth-basic\n" >> "$HOME/.netrc";

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ matrix:
       env: CI_TARGET=clang-report SCAN_BUILD=scan-build
       compiler: clang
     - os: osx
-      osx_image: xcode7.3  # Keep in sync with neovim/neovim's osx_image
+      osx_image: xcode9.4  # Keep in sync with neovim/neovim's osx_image
       env: CI_TARGET=nightly
       compiler: clang
     - env: CI_TARGET=nightly
@@ -49,8 +49,7 @@ install:
   - if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
       brew install bash;
       brew install jq;
-      brew install gettext;
-      brew reinstall libtool;
+      brew install libtool;
     fi;
     printf "machine github.com login ${GH_TOKEN:-unknown} password x-oauth-basic\n" >> "$HOME/.netrc";
     printf "machine api.github.com login ${GH_TOKEN:-unknown} password x-oauth-basic\n" >> "$HOME/.netrc";


### PR DESCRIPTION
Also gettext apparently no longer needs explicit install.
https://github.com/neovim/neovim/pull/9258

Except this means that our macOS binaries won't run on older macOS versions. So I don't know why that "Keep in sync" note is there.