### PR TITLE
vimpatch-report: Rewrite core in Python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,11 @@ matrix:
     - env: CI_TARGET=sync-lp-mirrors
     - env: CI_TARGET=user-docu
     - env: CI_TARGET=vimpatch-report
+      addons:
+        apt:
+          packages:
+            - python3
+            - python3-requests
     - env: CI_TARGET=clint-errors
     - os: linux
       env: CI_TARGET=pvs-report

--- a/ci/common/neovim.sh
+++ b/ci/common/neovim.sh
@@ -2,7 +2,7 @@
 
 require_environment_variable BUILD_DIR "${BASH_SOURCE[0]}" ${LINENO}
 
-NEOVIM_DIR=${NEOVIM_DIR:-${BUILD_DIR}/build/neovim}
+export NEOVIM_DIR=${NEOVIM_DIR:-${BUILD_DIR}/build/neovim}
 NEOVIM_REPO=${NEOVIM_REPO:-neovim/neovim}
 NEOVIM_BRANCH=${NEOVIM_BRANCH:-master}
 

--- a/ci/vimpatch-report.py
+++ b/ci/vimpatch-report.py
@@ -1,0 +1,95 @@
+#!/usr/bin/python3
+
+import html
+import requests
+import os
+import string
+
+
+def get_open_pullrequests():
+    pr_item = string.Template('<li><a href="${html_url}">${title}</a></li>')
+    url = "https://api.github.com/repos/neovim/neovim/pulls?state=open&per_page=100"
+    headers = {
+        "User-Agent": "neovim/bot-ci",
+    }
+    r = requests.get(url, headers)
+    r.raise_for_status()
+
+    def stringify(pr):
+        return pr_item.substitute(
+            html_url=pr["html_url"], title=html.escape(pr["title"])
+        )
+
+    prs = sorted(
+        (
+            {"html_url": pull["html_url"], "title": pull["title"]}
+            for pull in r.json()
+            if "vim-patch" in pull["title"]
+        ),
+        key=lambda x: x["title"],
+    )
+    return "\n".join(map(stringify, prs))
+
+
+tag_link = string.Template(
+    '<li><a href="https://github.com/vim/vim/tree/v8.0.${patch}">vim-patch:8.0.${patch}</a></li>'
+)
+
+
+def linkify_numbers(s):
+    return tag_link.substitute(patch="{:04d}".format(int(s)))
+
+
+def body_template_path():
+    return os.path.join(
+        os.getenv("BUILD_DIR"), "templates", "vimpatch-report", "body.sh.html"
+    )
+
+
+def version_path():
+    return os.path.join(os.getenv("NEOVIM_DIR"), "src", "nvim", "version.c")
+
+
+def parse_patches():
+    # Get patch information from src/nvim/version.c
+    #   - merged patches:   listed in version.c
+    #   - unmerged patches: commented-out in version.c
+    #   - N/A patches:      commented-out with "//123 NA"
+    in_patches = False
+    merged = []
+    not_merged = []
+    not_applicable = []
+    with open(version_path(), "r", encoding="utf-8") as fd:
+        for ln in fd:
+            if not in_patches:
+                in_patches = "static const int included_patches" in ln
+                continue
+            if "}" in ln:
+                break
+            ln = ln.strip(", \n")
+            if ln.startswith("//"):
+                if ln.endswith("NA"):
+                    not_applicable.append(
+                        linkify_numbers(ln.replace("//", "").replace("NA", ""))
+                    )
+                else:
+                    not_merged.append(linkify_numbers(ln.replace("//", "")))
+            else:
+                merged.append(linkify_numbers(ln))
+
+    return ("\n".join(merged), "\n".join(not_merged), "\n".join(not_applicable))
+
+
+if __name__ == "__main__":
+    pull_requests = get_open_pullrequests()
+    (merged, not_merged, not_applicable) = parse_patches()
+    with open(body_template_path(), "r", encoding="utf-8") as fd:
+        template = string.Template(fd.read())
+        print(
+            template.substitute(
+                pull_requests=pull_requests,
+                merged=merged,
+                not_merged=not_merged,
+                not_applicable=not_applicable,
+            )
+        )

--- a/ci/vimpatch-report.sh
+++ b/ci/vimpatch-report.sh
@@ -2,6 +2,7 @@
 set -e
 
 BUILD_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export BUILD_DIR
 source ${BUILD_DIR}/ci/common/common.sh
 source ${BUILD_DIR}/ci/common/dependencies.sh
 source ${BUILD_DIR}/ci/common/doc.sh
@@ -17,38 +18,7 @@ generate_vimpatch_report() {
 }
 
 get_vimpatch_report_body() {
-  # Get patch information from src/nvim/version.c
-  #   - merged patches:   listed in version.c
-  #   - unmerged patches: commented-out in version.c
-  #   - N/A patches:      commented-out with "//123 NA"
-  local patches=$(sed -n '/static const int included_patches/,/}/p' ${NEOVIM_DIR}/src/nvim/version.c |
-    grep -e '[0-9]' | sed 's/[ ,]//g' | grep -ve '^00*$')
-
-  merged=$(echo "${patches}" | grep -v \/\/ | linkify_numbers) \
-  not_merged=$(echo "${patches}" | grep \/\/ | grep -v NA | sed 's/\/\///g' | linkify_numbers) \
-  not_applicable=$(echo "${patches}" | grep -e '\/\/.*NA' | sed 's/\/\/\|NA//g' | linkify_numbers) \
-  pull_requests=$(get_open_pullrequests) \
-  envsubst < ${BUILD_DIR}/templates/vimpatch-report/body.sh.html
-}
-
-# Decorates a list of numbers as links to Vim's online repo.
-linkify_numbers() {
-  # zero-pad numbers less than 4 digits
-  awk -F: '{ printf("%04d\n", $1) }' |
-  sed 's![0-9]*!<li><a href="https://github.com/vim/vim/tree/v8.0.\0">vim-patch:8.0.\0</a></li>!'
-}
-
-# Generate HTML report of the current 'vim-patch' pull requests on GitHub
-get_open_pullrequests() {
-  curl --netrc -s -H "User-Agent: neovim/bot-ci" \
-    "https://api.github.com/repos/neovim/neovim/pulls?state=open&per_page=100" 2>/dev/null |
-  jq '[.[] | {html_url, title} |  select(contains({title: "vim-patch"}))] | sort_by(.title) | map("<li><a href=\"\(.html_url)\">\(.title)</a></li>")' |
-  # use sed until travis gets jq 1.3+ (has 'reduce' and '@html')
-  sed 's/^  "//' |
-  sed 's/\("\|",\)$//' |
-  sed 's/^\[//' |
-  sed 's/^\]//' |
-  sed 's/\\"/"/g'
+  python3 "${BUILD_DIR}/ci/vimpatch-report.py"
 }
 
 DOC_SUBTREE="/reports/vimpatch/"

--- a/ci/vimpatch-report.sh
+++ b/ci/vimpatch-report.sh
@@ -13,7 +13,8 @@ generate_vimpatch_report() {
   rm -rf ${DOC_DIR}/reports/vimpatch
   mkdir -p ${DOC_DIR}/reports/vimpatch
 
-  generate_report "Vim Patch Report" "$(get_vimpatch_report_body)" \
+  body=$(get_vimpatch_report_body)
+  generate_report "Vim Patch Report" "${body}" \
     ${DOC_DIR}/reports/vimpatch/index.html
 }
 


### PR DESCRIPTION
When there are a lot of patches in version.c, the environment variables were too large causing the script to fail:

    ./ci/vimpatch-report.sh: line 49: /bin/sed: Argument list too long
    ./ci/vimpatch-report.sh: line 51: /bin/sed: Argument list too long
    ./ci/vimpatch-report.sh: line 45: /usr/local/bin/jq: Argument list too long
    ./ci/vimpatch-report.sh: line 50: /bin/sed: Argument list too long
    ./ci/vimpatch-report.sh: line 48: /bin/sed: Argument list too long
    ./ci/vimpatch-report.sh: line 47: /bin/sed: Argument list too long
    ./ci/vimpatch-report.sh: line 27: /usr/bin/envsubst: Argument list too long

vimpatch-report.py now does all the data processing and dumps the html body to stdout.