### PR TITLE
Split nightly jobs into their own stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,10 @@ env:
     - secure: N73UKR9bIcAh5q+YXdru8iWdMJh6V85PMtl14ZK4EzTi1MP8AcSuTEJMOAizGOcYL+jL7tM/Kd8rxsJVYcwdqIPij4jugNsm4UZLgxAoI1rZ2wpUHAqQdknTFGzss64UuNehbcEM82aK5/qbtvzU3eM8UVVVsuTg8SvB+XAmdI4=
     # COVERITY_SCAN_TOKEN
     - secure: pgI3Qt7bCRDeuKX38hP9xTJ6CdbwoUkcPToHnfDFYeclhUJRgCfZhCKKO+zTwqoa2Jx7wShoFeHaKidOFctg4ls4lrn47b0bPFED3LtU7RDQaeamqFKzgTV1IcEpkUfGl/i8tOmaEd7UvyUHKuKZmjmVr4Ce4ugATShYB186EW0=
-matrix:
+jobs:
   include:
-    - env: CI_TARGET=assign-labels
+    - stage: common
+      env: CI_TARGET=assign-labels
     - env: CI_TARGET=auto-pullrequest
     - env: CI_TARGET=deps-src
     - env: CI_TARGET=doc-index
@@ -39,11 +40,13 @@ matrix:
     - os: linux
       env: CI_TARGET=clang-report SCAN_BUILD=scan-build
       compiler: clang
-    - os: osx
+    - stage: Linux/Windows Nightly
+      env: CI_TARGET=nightly
+    - stage: macOS Nightly
+      os: osx
       osx_image: xcode10.1
       env: CI_TARGET=nightly
       compiler: clang
-    - env: CI_TARGET=nightly
 #    - os: linux
 #      env: CI_TARGET=coverity
 #  allow_failures:


### PR DESCRIPTION
The Linux/Windows nightly job needs to run before macOS, otherwise the
macOS binaries will be attached to the release that gets replaced.

Closes #152
Closes neovim/neovim#13146

Cc @erw7